### PR TITLE
Add Support for ST-MFNet Demo on Replicate and API Access

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 [Project](https://danier97.github.io/ST-MFNet) | [Paper](https://openaccess.thecvf.com/content/CVPR2022/html/Danier_ST-MFNet_A_Spatio-Temporal_Multi-Flow_Network_for_Frame_Interpolation_CVPR_2022_paper.html) | [arXiv](https://arxiv.org/abs/2111.15483) | [Video](https://drive.google.com/file/d/1zpE3rCQNJi4e8ADNWKbJA5wTvPllKZSj/view) | [Poster](https://danier97.github.io/ST-MFNet/ST_MFNet_CVPR_poster.pdf)
 
+[![Replicate](https://replicate.com/zsxkib/st-mfnet/badge)](https://replicate.com/zsxkib/st-mfnet)
 
 ## Dependencies and Installation
 The following packages were used to evaluate the model.

--- a/cog.yaml
+++ b/cog.yaml
@@ -1,0 +1,59 @@
+# Configuration for Cog ⚙️
+# Reference: https://github.com/replicate/cog/blob/main/docs/yaml.md
+
+build:
+  # set to true if your model requires a GPU
+  gpu: true
+  cuda: "11.7.1"
+
+  # a list of ubuntu apt packages to install
+  system_packages:
+    - "libgl1-mesa-glx"
+    - "ffmpeg"
+    - "x264"
+    - "libx264-dev"
+
+  # python version in the form '3.8' or '3.8.12'
+  python_version: "3.8.17"
+
+  # a list of packages in the format <package-name>==<version>
+  python_packages:
+    - "ipykernel"
+    - "cupy-cuda11x"
+    - "certifi==2023.7.22"
+    - "charset-normalizer==3.2.0"
+    - "cmake==3.27.4.1"
+    - "filelock==3.12.3"
+    - "idna==3.4"
+    - "jinja2==3.1.2"
+    - "lit==16.0.6"
+    - "markupsafe==2.1.3"
+    - "mpmath==1.3.0"
+    - "networkx==3.1"
+    - "numpy==1.20.0"
+    - "nvidia-cublas-cu11==11.10.3.66"
+    - "nvidia-cuda-cupti-cu11==11.7.101"
+    - "nvidia-cuda-nvrtc-cu11==11.7.99"
+    - "nvidia-cuda-runtime-cu11==11.7.99"
+    - "nvidia-cudnn-cu11==8.5.0.96"
+    - "nvidia-cufft-cu11==10.9.0.58"
+    - "nvidia-curand-cu11==10.2.10.91"
+    - "nvidia-cusolver-cu11==11.4.0.1"
+    - "nvidia-cusparse-cu11==11.7.4.91"
+    - "nvidia-nccl-cu11==2.14.3"
+    - "nvidia-nvtx-cu11==11.7.91"
+    - "pillow==10.0.0"
+    - "requests==2.31.0"
+    - "scipy==1.10.1"
+    - "setuptools==68.1.2"
+    - "sk-video==1.1.10"
+    - "sympy==1.12"
+    - "torch"
+    - "torchvision"
+    - "tqdm==4.66.1"
+    - "triton==2.0.0"
+    - "urllib3==2.0.4"
+    - "opencv-contrib-python"
+
+# predict.py defines how predictions are run on your model
+predict: "predict.py:Predictor"

--- a/models/misc/resnet_3D.py
+++ b/models/misc/resnet_3D.py
@@ -1,6 +1,6 @@
 import torch
 import torch.nn as nn
-from torchvision.models.utils import load_state_dict_from_url
+from torch.utils.model_zoo import load_url as load_state_dict_from_url # NOTE: # Was `from torchvision.models.utils import load_state_dict_from_url` but torch has changed import
 from models.misc import Identity as identity
 
 model_urls = {

--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,176 @@
+# Prediction interface for Cog ⚙️
+# https://github.com/replicate/cog/blob/main/docs/python.md
+
+import math
+from types import SimpleNamespace
+from typing import List
+import os
+import subprocess
+
+import cv2
+import torch
+import torchvision.transforms.functional as TF
+from tqdm import tqdm
+from cog import BasePredictor, Input, Path
+
+from utility import tensor2rgb
+from models.stmfnet import STMFNet
+
+
+class Predictor(BasePredictor):
+    def setup(self):
+        """
+        Set up the prediction environment.
+
+        This method initializes the model, its parameters, and the GPU device for computation.
+        It also loads the STMFNet model using the specified checkpoint.
+        Lastly, it ensures there is an output directory for storing the enhanced videos.
+        """
+
+        args = SimpleNamespace(
+            **{
+                "gpu_id": (gpu_id := 0),
+                "net": (net := "STMFNet"),
+                "checkpoint": (checkpoint := "stmfnet.pth"),
+                "size": (size := "1920x1080"),
+                "patch_size": (patch_size := None),
+                "overlap": (overlap := None),
+                "batch_size": (batch_size := None),
+                "out_fps": (out_fps := 144),
+                "out_dir": (out_dir := "."),
+                "featc": (featc := [64, 128, 256, 512]),
+                "featnet": (featnet := "UMultiScaleResNext"),
+                "featnorm": (featnorm := "batch"),
+                "kernel_size": (kernel_size := 5),
+                "dilation": (dilation := 1),
+                "finetune_pwc": (finetune_pwc := False),
+            }
+        )
+        torch.cuda.set_device(gpu_id)
+
+        self.net = net
+        self.size = size
+        self.model = STMFNet(args).cuda()
+        print("Loading the model...")
+        checkpoint = torch.load(checkpoint)
+        self.model.load_state_dict(checkpoint["state_dict"])
+        self.model.eval()
+
+        if not os.path.exists(out_dir):
+            os.makedirs(out_dir)
+
+    def predict(
+        self,
+        mp4: Path = Input(description="Upload an mp4 video file."),
+        keep_original_duration: bool = Input(
+            description="Should the enhanced video retain the original duration? If set to `True`, the model will adjust the frame rate to maintain the video's original duration after adding interpolated frames. If set to `False`, the frame rate will be set based on `custom_fps`.",
+            default=True,
+        ),
+        custom_fps: float = Input(
+            description="Set `keep_original_duration` to `False` to use this! Desired frame rate (fps) for the enhanced video. This will only be considered if `keep_original_duration` is set to `False`.",
+            default=None,
+            ge=1,
+            le=240,
+        ),
+        framerate_multiplier: int = Input(
+            description="Determines how many intermediate frames to generate between original frames. E.g., a value of 2 will double the frame rate, and 4 will quadruple it, etc.",
+            default=2,
+            choices=[2, 4, 8, 16, 32],
+        ),
+    ) -> List[Path]:
+        """
+        Enhance a video by increasing its frame rate using frame interpolation.
+
+        Parameters:
+        - mp4 (Path): Path to the video file.
+        - keep_original_duration (bool): Indicator to maintain the original video duration after frame interpolation.
+        - custom_fps (float): Target frame rate for the enhanced video when not maintaining the original duration.
+        - framerate_multiplier (int): Multiplier for the number of frames.
+
+        Returns:
+        List[Path]: Paths to the generated enhanced video files.
+        """
+
+        num_iterations = int(math.log2(framerate_multiplier))
+        original_seq_name = os.path.basename(mp4).split(".")[0]
+
+        for enhancing_iteration in tqdm(range(num_iterations), desc="Enhancing iterations"):
+            # Opening the video and extracting essential properties
+            video = cv2.VideoCapture(str(mp4))
+            original_video_fps = video.get(cv2.CAP_PROP_FPS)
+            width, height = int(video.get(cv2.CAP_PROP_FRAME_WIDTH)), int(video.get(cv2.CAP_PROP_FRAME_HEIGHT))
+            original_num_frames = sum(video.read()[0] for _ in range(int(video.get(cv2.CAP_PROP_FRAME_COUNT))))
+
+            # Informing the user of video details before processing
+            print(f"Video Name: {original_seq_name}")
+            print(f"Original Frame Rate (FPS): {original_video_fps}")
+            print(f"Original Total Number of Frames: {original_num_frames}")
+
+            img_array = []
+            # Processing each set of 4 frames for frame rate enhancement
+            for t in tqdm(range(0, original_num_frames - 3), desc="Processing frames"):
+                video.set(cv2.CAP_PROP_POS_FRAMES, t)
+                _, rawFrame0 = video.read()
+                _, rawFrame1 = video.read()
+                _, rawFrame2 = video.read()
+                _, rawFrame3 = video.read()
+
+                # If any frame in the set of 4 is missing, stop processing
+                if any(frame is None for frame in [rawFrame0, rawFrame1, rawFrame2, rawFrame3]):
+                    break
+
+                # Convert frames to tensors and move them to GPU
+                frame0 = TF.to_tensor(rawFrame0)[None, ...].cuda()
+                frame1 = TF.to_tensor(rawFrame1)[None, ...].cuda()
+                frame2 = TF.to_tensor(rawFrame2)[None, ...].cuda()
+                frame3 = TF.to_tensor(rawFrame3)[None, ...].cuda()
+
+                # Use the trained model to predict enhanced frames
+                with torch.no_grad():
+                    out = self.model(frame0, frame1, frame2, frame3)
+
+                # Special handling for the very first
+                if t == 0:
+                    img_array += [tensor2rgb(frame0)[0]] * 2 + [tensor2rgb(frame1)[0]]
+
+                img_array += [tensor2rgb(out)[0], tensor2rgb(frame2)[0]]
+
+                # Special handling for the last sets of frames
+                if t == original_num_frames - 4:
+                    img_array += [tensor2rgb(frame3)[0]] * 2
+            video.release()
+
+            # Decide the output video's fps
+            new_num_frames = len(img_array)
+            output_fps = (
+                new_num_frames * original_video_fps
+            ) / original_num_frames  # Compute the fps that keeps video playback constant (duration of video)
+            if (not keep_original_duration) and (custom_fps is not None) and (custom_fps >= 1):
+                output_fps = custom_fps
+
+            # Create and write frames to the output video
+            avi_outname = f"{original_seq_name}_{enhancing_iteration}.avi"
+            new_num_frames = len(img_array)
+
+            print(f"Output filename: {avi_outname}")
+            print(f"New Total Number of Frames: {new_num_frames}")
+
+            cv2writer = cv2.VideoWriter(
+                avi_outname,
+                cv2.VideoWriter_fourcc(*"DIVX"),  # NOTE: codec issues mean we have to export as avi using DIVX
+                output_fps,
+                (width, height),
+            )
+
+            for frame in img_array:
+                cv2writer.write(frame)
+            cv2writer.release()
+
+            # Convert the AVI video to MP4 format using ffmpeg (NOTE: We use ffmpeg because we have codec issues with cv2 and mp4)
+            mp4_outname = avi_outname.replace(".avi", ".mp4")
+            cmd = ["ffmpeg", "-i", avi_outname, mp4_outname, "-y"]
+            subprocess.run(cmd)
+
+            # Append the output path and prepare for the next iteration if needed
+            mp4 = mp4_outname
+            yield Path(mp4_outname)


### PR DESCRIPTION
Hello Duolikun, Fan, and David,

Firstly, kudos on the fantastic work with ST-MFNet and the acceptance into CVPR 2022. The results are genuinely impressive!

I've gone ahead and made some changes that enable running the ST-MFNet demo directly on Replicate. This makes it accessible to a wider audience without the need for a local setup, further promoting your excellent work. Here are the specifics:

- **ST-MFNet on Replicate:** Users can now test and interact with the ST-MFNet directly from [this link on Replicate](https://replicate.com/zsxkib/st-mfnet). 

- **API Access:** For those who prefer programmatic access or wish to integrate ST-MFNet into their pipelines, the model is also available via [API here](https://replicate.com/zsxkib/st-mfnet/api).

I believe these changes can further simplify the user experience and make ST-MFNet even more accessible to the community. Please review the modifications, and I look forward to your feedback!

Best regards,
Sakib @ Replicate